### PR TITLE
Update anchor from npm to 0.31.2

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: metaDAOproject/setup-anchor@v3.1
         with:
-          anchor-version: "0.31.1"
+          anchor-version: "0.31.2"
           solana-cli-version: "2.1.21"
           node-version: "22.14.0"
 
@@ -32,14 +32,6 @@ jobs:
         run: |
           rustup toolchain install $RUSTUP_TOOLCHAIN
           rustup component add --toolchain $RUSTUP_TOOLCHAIN cargo clippy rust-docs rust-std rustc rustfmt
-
-      # Fix for https://github.com/solana-foundation/anchor/issues/3596
-      # TODO: Remove this once the issue is fixed
-      - name: Manually download Anchor binary
-        run: |
-          wget https://github.com/coral-xyz/anchor/releases/download/v0.31.1/anchor-0.31.1-x86_64-unknown-linux-gnu
-          chmod +x anchor-0.31.1-x86_64-unknown-linux-gnu
-          mv anchor-0.31.1-x86_64-unknown-linux-gnu `which anchor`
 
       # Pre-download Cargo dependencies to avoid messages during version checks
       - name: Pre-download dependencies


### PR DESCRIPTION
I found this repo very useful. Thank you, @mikemaccana!

As I remember, there were some problems updating this, but CI looks ok in my fork
https://github.com/davidyuk/anchor-election-2025/actions/runs/17516016066/job/49753598947